### PR TITLE
feat: inject config into JwtModule and use enum for roles

### DIFF
--- a/src/auth/auth.module.ts
+++ b/src/auth/auth.module.ts
@@ -1,16 +1,18 @@
 import { Module } from '@nestjs/common';
+import { ConfigType } from '@nestjs/config';
+import { JwtModule } from '@nestjs/jwt';
 import { AuthService } from './auth.service';
 import { AuthController } from './auth.controller';
-import { JwtModule } from '@nestjs/jwt';
+import { jwtConfig } from '../config/jwt.config';
 
 @Module({
   imports: [
     JwtModule.registerAsync({
-      /*     imports: [ConfigModule],
-      useFactory: async (configService: ConfigService) => ({
-        secret: configService.get<string>('jwt_secret'),
+      useFactory: (config: ConfigType<typeof jwtConfig>) => ({
+        secret: config.accessSecret,
+        signOptions: { expiresIn: config.accessExpiresIn },
       }),
-      inject: [ConfigService], */
+      inject: [jwtConfig.KEY],
     }),
   ],
   controllers: [AuthController],

--- a/src/auth/auth.types.ts
+++ b/src/auth/auth.types.ts
@@ -1,5 +1,7 @@
+import { UserRole } from '../users/users.enum';
+
 export interface JwtPayload {
   sub: string;
   email: string;
-  role: 'user' | 'admin';
+  role: UserRole;
 }

--- a/src/config/jwt.config.ts
+++ b/src/config/jwt.config.ts
@@ -1,10 +1,11 @@
 import { registerAs } from '@nestjs/config';
+import type { StringValue } from 'ms';
 
 export const jwtConfig = registerAs('JWT_CONFIG', () => ({
   accessSecret: process.env.JWT_ACCESS_SECRET || 'access-secret-key',
   refreshSecret: process.env.JWT_REFRESH_SECRET || 'refresh-secret-key',
-  accessExpiresIn: process.env.JWT_ACCESS_EXPIRES_IN || '1h',
-  refreshExpiresIn: process.env.JWT_REFRESH_EXPIRES_IN || '7d',
+  accessExpiresIn: (process.env.JWT_ACCESS_EXPIRES_IN || '1h') as StringValue,
+  refreshExpiresIn: (process.env.JWT_REFRESH_EXPIRES_IN || '7d') as StringValue,
 }));
 
 export type IJwtConfig = ReturnType<typeof jwtConfig>;

--- a/src/users/users.enum.ts
+++ b/src/users/users.enum.ts
@@ -1,0 +1,4 @@
+export enum UserRole {
+  USER = 'user',
+  ADMIN = 'admin',
+}


### PR DESCRIPTION
Предлагаю оставить JwtModule пустым, а конфиг инжектить напрямую в AuthService и стратегии — для двух типов токенов (Access/Refresh) с разными секретами это подходит лучше.